### PR TITLE
Fixes warning NU1608: Detected package version outside of dependency constraint

### DIFF
--- a/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
+++ b/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
@@ -11,8 +11,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
 		<PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
 		<PackageReference Include="Verify.Xunit" Version="31.9.3" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
+++ b/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
 		<PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
 		<PackageReference Include="Verify.Xunit" Version="31.9.3" />

--- a/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
+++ b/src/DragonFruit2.Generators.Test/DragonFruit2.Generators.Test.csproj
@@ -11,10 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
 		<PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
 		<PackageReference Include="Verify.Xunit" Version="31.9.3" />


### PR DESCRIPTION
Fixes "warning NU1608: Detected package version outside of dependency constraint" when compiling DragonFruit2.Generators.Test as described in issue #51 